### PR TITLE
Add references to derivation and calibration repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Soil Power Sensor
+
+This repo contains the EagleCAD source files for the PCB design of the Soil Power Sensor. The Soil Power Sensor is a iteration on the design of CurrentSense by Lab11(https://github.com/lab11/CurrentSense). Information on the calibration and evalutation including instructions, data files, and scripts are available in the repo, https://github.com/jlab-sensing/soil-power-sensor-calibration.


### PR DESCRIPTION
I added a README that gives references to the original version https://github.com/lab11/CurrentSense along with the calibration files https://github.com/jlab-sensing/soil-power-sensor-calibration. This is in preparation for the ENSsys conference to make it easier to access both the design files and calibration process.